### PR TITLE
Store and use token expiry date time

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -2,14 +2,16 @@ package account
 
 import (
 	"github.com/dchest/uniuri"
+	"time"
 )
 
 // Account holds a user account
 type Account struct {
-	Username     string `json:"username,omitempty"`
-	Password     string `json:"password,omitempty"`
-	AccessToken  string `json:"access_token,omitempty"`
-	RefreshToken string `json:"refresh_token,omitempty"`
+	Username     string    `json:"username,omitempty"`
+	Password     string    `json:"password,omitempty"`
+	AccessToken  string    `json:"access_token,omitempty"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	TokenExpiry  time.Time `json:"token_expiry,omitempty"`
 }
 
 // NewWithRandomPassword creates a new Account with a random password

--- a/cmd/radioauth/http-server.go
+++ b/cmd/radioauth/http-server.go
@@ -114,6 +114,7 @@ func runHTTPServer() {
 		}
 
 		a.AccessToken = oauth2Token.AccessToken
+		a.TokenExpiry = oauth2Token.Expiry
 		err = accountStore.Write(a)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/cmd/radioauth/main.go
+++ b/cmd/radioauth/main.go
@@ -37,6 +37,7 @@ func authenticateToken(account *account.Account) bool {
 	oauth2Token := oauth2.Token{
 		AccessToken:  account.AccessToken,
 		RefreshToken: account.RefreshToken,
+		Expiry:       account.TokenExpiry,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)


### PR DESCRIPTION
The expiry date time is required to figure out when the refresh token
must be used. When the expiry field is not present the value is assumed
to be 0 which implies the token is not refreshable and will therefor not
be refreshed.